### PR TITLE
Changes for Learn Chef integration

### DIFF
--- a/marketo_chef.gemspec
+++ b/marketo_chef.gemspec
@@ -33,7 +33,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'faraday',            '>= 0.11'
+  # This gem needs to be compatible with OmniAuth (used on the Learn Chef site)
+  # which depends on the OAuth2 gem, which requires faraday ['>= 0.8', '< 0.12']
+  # https://github.com/intridea/oauth2/blob/v1.3.1/oauth2.gemspec
+  spec.add_runtime_dependency 'faraday',            '~> 0.11.0'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.11'
 
   spec.add_development_dependency 'bundler',  '~> 1.14'


### PR DESCRIPTION
@TrevorBramble Here are workarounds for three issues I came across working on the integration with the Learn Chef site:

1. Relax Faraday dependency to v0.11 to work with OmniAuth: Let me know if this won't work, but I couldn't find another way around this gem dependency issue.

2. Allow host variable to be a fully qualified URL: I was using "https://255-VFB-268.mktoapi.com" as the host, and getting a Faraday error. I did a lot of reading trying to figure this out, to no avail, but then looked at the source where I found that "https://" was being prepended.

3. Raise useful error message if response body is a string: res.body was coming back as a string and erroring on the next line, because Marketo was returning a "The document has moved" message. Eventually I found the solution was to use "255-VFB-268.mktorest.com" as the host.

Let me know if you have any questions or concerns. While #2 and #3 are just here to help any future integrations from running into the same issues I did, #1 is necessary to test the Marketo integration on Learn Chef.